### PR TITLE
change: CIが利用するNode.jsから10.xを削除し16.xを追加した

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node.js 10.xはサポートが終了したので削除。入れ替わりで新たに16.xがサポートされたので追加。